### PR TITLE
Updated the desc that how to install Inconsolata on Debian / Ubuntu

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Makefile、LaTeX など、UNIX 系のコーディングにおける使用を想�
 ## Inconsolata のインストール
 ### Debian/Ubuntu
 
-    # apt-get install ttf-inconsolata
+    # apt install fonts-inconsolata
 
 ### その他の Linux
 [Inconsolata 公式サイト](http://levien.com/type/myfonts/inconsolata.html)より


### PR DESCRIPTION
# Overview

This PR include `README.md` diff that how to install Inconsolata on Debian / Ubuntu.

- Not Found: ttf-inconsolata
- Found: fonts-inconsolata

Thus, please would you like to see the package manager arguments?

Before (current) :

![before](https://user-images.githubusercontent.com/359823/81134253-227e0180-8f8f-11ea-88a8-e8d05faa7653.png)

After (this PR) : 

![after](https://user-images.githubusercontent.com/359823/81134257-2578f200-8f8f-11ea-8bf3-be05768361ea.png)

# Notes

Inconsolate packages (fonts-inconsolata) is here:

- Ubuntu package: https://packages.ubuntu.com/search?keywords=inconsolata&searchon=names&suite=eoan&section=all
- Debian package: https://packages.debian.org/stable/fonts/fonts-inconsolata